### PR TITLE
Code Refactor

### DIFF
--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -126,8 +126,8 @@ function getLocalPaintsArray(types: string) {
                 };
                 if (name.includes('/')) {
                     const [themes, colorName] = name.split('/');
-                    style.theme = themes;
-                    style.name = colorName;
+                    style.theme = themes.replace(/ /g, '').toLowerCase();
+                    style.name = colorName.replace(/ /g, '').toLowerCase();
                 }
 
                 if (style.name && style.key && style.theme && style.type) {


### PR DESCRIPTION
Added regex expression to get rid of any spacing while fetching the string for theme name or color. All strings will now be converted to lower case to further eliminate duplications.